### PR TITLE
Fix broken links for notebook

### DIFF
--- a/multimodal-understanding/getting-started/05_chat_with_document_kb.ipynb
+++ b/multimodal-understanding/getting-started/05_chat_with_document_kb.ipynb
@@ -12,7 +12,7 @@
     "## Chat with your document using Knowledge Bases for Amazon Bedrock - RetrieveAndGenerate API\n",
     " With `chat with your document` capability, you can securely ask questions on single documents, without the overhead of setting up a vector database or ingesting data, making it effortless for businesses to use their enterprise data. You only need to provide a relevant data file as input and choose your FM to get started.\n",
     "\n",
-    "For details around use cases and benefits, please refer to this [blogpost](#https://aws.amazon.com/blogs/machine-learning/knowledge-bases-in-amazon-bedrock-now-simplifies-asking-questions-on-a-single-document/).\n",
+    "For details around use cases and benefits, please refer to this [blogpost](https://aws.amazon.com/blogs/machine-learning/knowledge-bases-in-amazon-bedrock-now-simplifies-asking-questions-on-a-single-document/).\n",
     "\n",
     "### Pre-requisites\n",
     "##### Python 3.10\n",
@@ -329,7 +329,7 @@
     "\n",
     "To further explore the capabilities of Knowledge Bases for Amazon Bedrock, refer to the following resources:\n",
     "\n",
-    "[Knowledge bases for Amazon Bedrock](#https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base.html)\n"
+    "[Knowledge bases for Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/knowledge-base.html)\n"
    ]
   }
  ],


### PR DESCRIPTION
*Issue #, if available:* N/A, didn't think this needed an issue since it's such a small contribution.

*Description of changes:* The links were prefaced by a `#` so they weren't redirecting to the actual pages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
