### PR TITLE
Correct datetime import to resolve AttributeError

### DIFF
--- a/multimodal-understanding/getting-started/01_getting_started.ipynb
+++ b/multimodal-understanding/getting-started/01_getting_started.ipynb
@@ -120,7 +120,7 @@
     "import boto3\n",
     "import json\n",
     "import base64\n",
-    "import datetime\n",
+    "from datetime import datetime\n",
     "\n",
     "PRO_MODEL_ID = \"us.amazon.nova-pro-v1:0\"\n",
     "LITE_MODEL_ID = \"us.amazon.nova-lite-v1:0\"\n",


### PR DESCRIPTION


*Description of changes:*

The code in section "2.2 Streaming API Call" in the notebook `multimodal-understanding/getting-started/01_getting_started.ipynb` throws the follwing error when executing:

> AttributeError: module 'datetime' has no attribute 'now'"

This PR fixed the import at top of the notebook to   `from datetime import datetime` so that there is not AttributeError anymore

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
