### PR TITLE
Fixed syntax in CloudFormation template and updated README.md

### DIFF
--- a/multimodal-understanding/workshop/README.md
+++ b/multimodal-understanding/workshop/README.md
@@ -23,9 +23,10 @@ In this workshop, we will explore the Nova family of multimodal models. There ar
 3. Wait a few seconds, then click **open** to access
 4. Clone this repo in your Sagemaker studio instance
 5. Open the **multimodal-understanding/workshop** to complete the workshop
-6. Please add the following permissions to the SageMaker execution role
+6. Please Copy the following CloudFormation template and save it into file called **sagemakerexecutionrole.yml**. In CloudFormation console,  create a stack using the saved CloudFormation template to create the SageMaker execution role
 
 ```
+Resources:
  SageMakerExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -62,7 +63,6 @@ In this workshop, we will explore the Nova family of multimodal models. There ar
                   - logs:*
                   - cloudwatch:*
                 Resource: '*'
-      Policies:
         - PolicyName: s3-access
           PolicyDocument:
             Version: 2012-10-17
@@ -286,6 +286,7 @@ In this workshop, we will explore the Nova family of multimodal models. There ar
                   - 'arn:aws:bedrock:*:*:inference-profile/us.amazon.*'
                   - 'arn:aws:bedrock:*:*:application-inference-profile/*'
 ``` 
+7. Validate the CloudFormation template was deployed succesfully by going to the Resources Tab in the cloudFormation console and take note of the role name 
 
 ## Workshop Structure
 


### PR DESCRIPTION
*Issue  https://github.com/aws-samples/amazon-nova-samples/issues/38:*

*Description of changes:*

Fixed the CloudFormation Template syntax errors in Line-1 and Line 37.
Updated the ReadME to reflect the attached is not an AWS IAM policy but a CloudFormation template to create the SageMAker Execution role along with the required policies. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
