### PR TITLE
Fix call to llm_with_tools instead of llm

### DIFF
--- a/multimodal-understanding/getting-started/04_langchain_integration.ipynb
+++ b/multimodal-understanding/getting-started/04_langchain_integration.ipynb
@@ -349,7 +349,7 @@
     "    ]\n",
     ")\n",
     "\n",
-    "agent = create_tool_calling_agent(llm, tools, prompt)\n",
+    "agent = create_tool_calling_agent(llm_with_tools, tools, prompt)\n",
     "\n",
     "agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)\n",
     "\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the Tool Calling Agents section of the notebook, a call is made to `llm` rather than `llm_with_tools`. This results in the earlier `llm` object being called (from the streaming section - created on row 226) with the wrong temperature and configuration.  

Note the call to `bind_tools(tools)` on row 338 also may not be required, as the tools are passed to the agent on row 352.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
