### PR TITLE
Fix typo in speech-to-speech README title

### DIFF
--- a/speech-to-speech/README.md
+++ b/speech-to-speech/README.md
@@ -1,4 +1,4 @@
-# Amazon Nova Sonic Spoeech-to-Speech Model Samples 
+# Amazon Nova Sonic Speech-to-Speech Model Samples 
 
 The Amazon Nova Sonic model provides real-time, conversational interactions through bidirectional audio streaming. Amazon Nova Sonic processes and responds to real-time speech as it occurs, enabling natural, human-like conversational experiences.
 


### PR DESCRIPTION
# Fix typo in speech-to-speech README title

## Description
This PR fixes a typo in the title of the speech-to-speech README.md file, changing "Spoeech-to-Speech" to "Speech-to-Speech".

## Changes
- Corrected the spelling of "Speech" in the README.md title

## Testing
- Verified the README.md file displays correctly with the fixed title

## Related Issues
N/A