### PR TITLE
Fix typo: Change 'AmazonNova' to 'Amazon Nova' for consistent branding

### DIFF
--- a/multimodal-generation/image-generation/README.md
+++ b/multimodal-generation/image-generation/README.md
@@ -1,6 +1,6 @@
 # Amazon Nova Canvas Image Generator Code Samples
 
-This repository includes code examples for common image generation and editing tasks using AmazonNova Canvas image generation model. Examples are provided in Python (.py), Jupyter Notebook (.ipynb), and Javascript (.js) formats. Sample images for use with these scripts have also been provided.
+This repository includes code examples for common image generation and editing tasks using Amazon Nova Canvas image generation model. Examples are provided in Python (.py), Jupyter Notebook (.ipynb), and Javascript (.js) formats. Sample images for use with these scripts have also been provided.
 
 ## Setup - Permissions and Model Entitlement
 

--- a/multimodal-generation/video-generation/README.md
+++ b/multimodal-generation/video-generation/README.md
@@ -1,6 +1,6 @@
 # Amazon Nova Reel Video Generator Code Samples
 
-This repository includes code examples for common image generation and editing tasks using AmazonNova Reel video generation model. Examples are provided in Python (.py), Jupyter Notebook (.ipynb), and Javascript (.js) formats. Sample images for use with these scripts have also been provided.
+This repository includes code examples for common image generation and editing tasks using Amazon Nova Reel video generation model. Examples are provided in Python (.py), Jupyter Notebook (.ipynb), and Javascript (.js) formats. Sample images for use with these scripts have also been provided.
 
 ## Setup - Permissions and Model Entitlement
 


### PR DESCRIPTION
# Fix branding inconsistency in README files

## Description
This PR fixes a branding inconsistency in two README files where "AmazonNova" was incorrectly used instead of the proper "Amazon Nova" format.

## Changes
- Changed "AmazonNova Canvas" to "Amazon Nova Canvas" in image-generation README
- Changed "AmazonNova Reel" to "Amazon Nova Reel" in video-generation README

## Testing
- Verified the README files display correctly with consistent branding

## Related Issues
N/A