### PR TITLE
Adding checks to pick available fonts

### DIFF
--- a/multimodal-understanding/repeatable-patterns/13-image-grounding/image_grounding.ipynb
+++ b/multimodal-understanding/repeatable-patterns/13-image-grounding/image_grounding.ipynb
@@ -79,6 +79,29 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_font(height):\n",
+    "    try:\n",
+    "        font = ImageFont.truetype(\"Arial\", size=height // 20)\n",
+    "    except (OSError, IOError):\n",
+    "        # Fallback to default font\n",
+    "        try:\n",
+    "            # Try loading system default font\n",
+    "            # Try loading system default font\n",
+    "            \n",
+    "            font = ImageFont.load_default()\n",
+    "            print(\"Using default font as Arial font not found\")\n",
+    "        except Exception as e:\n",
+    "            print(f\"Error loading default font: {e}\")\n",
+    "            # If even default font fails, you might want to handle this case\n",
+    "            raise"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -87,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +191,7 @@
     "        'pink',\n",
     "        'purple',\n",
     "    ]\n",
-    "    font = ImageFont.truetype(\"Arial\", size=height // 20)\n",
+    "    font = get_font(height)\n",
     "\n",
     "    print(\"Result:\\n\")\n",
     "    for idx, item in enumerate(result):\n",


### PR DESCRIPTION
Issue #, if available:
Font loading error when executing the notebook with SageMaker AI

Description of changes:
Added a try-catch to check for availability of Arial font and switch to default available font in case of exception while loading Arial.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.