### PR TITLE
fix: resolve audio playback issues in react-client

### DIFF
--- a/speech-to-speech/workshops/react-client/src/helper/audioPlayer.js
+++ b/speech-to-speech/workshops/react-client/src/helper/audioPlayer.js
@@ -9,19 +9,39 @@ export default class AudioPlayer {
     async start() {
         if (this.initialized) return;
 
-        this.audioContext = new AudioContext({ "sampleRate": 24000 });
-        this.analyser = this.audioContext.createAnalyser();
-        this.analyser.fftSize = 512;
+        try {
+            this.audioContext = new AudioContext({ "sampleRate": 24000 });
+            this.analyser = this.audioContext.createAnalyser();
+            this.analyser.fftSize = 512;
 
-        // Load the audio worklet
-        const workletUrl = new URL('./audioPlayerProcessor.worklet.js', import.meta.url).toString();
-        await this.audioContext.audioWorklet.addModule(workletUrl);
+            // Load the audio worklet
+            const workletUrl = new URL('./audioPlayerProcessor.worklet.js', import.meta.url).toString();
+            await this.audioContext.audioWorklet.addModule(workletUrl);
 
-        this.workletNode = new AudioWorkletNode(this.audioContext, "audio-player-processor");
-        this.workletNode.connect(this.analyser);
-        this.analyser.connect(this.audioContext.destination);
+            this.workletNode = new AudioWorkletNode(this.audioContext, "audio-player-processor");
+            this.workletNode.connect(this.analyser);
+            this.analyser.connect(this.audioContext.destination);
 
-        this.initialized = true;
+            // Add error handling for the worklet
+            this.workletNode.onprocessorerror = (err) => {
+                console.error("AudioWorklet processing error:", err);
+            };
+
+            this.initialized = true;
+            
+            // Ensure the audio context is running
+            if (this.audioContext.state !== 'running') {
+                console.log("Attempting to resume AudioContext...");
+                await this.audioContext.resume();
+            }
+            
+            console.log("Audio player initialized successfully");
+        } catch (error) {
+            console.error("Failed to initialize audio player:", error);
+            // Clean up any partially initialized resources
+            this.stop();
+            throw error;
+        }
     }
 
     bargeIn() {
@@ -55,6 +75,19 @@ export default class AudioPlayer {
     playAudio(samples) {
         if (!this.initialized) {
             console.error("The audio player is not initialized. Call start() before attempting to play audio.");
+            return;
+        }
+
+        // Resume the AudioContext if it's suspended
+        if (this.audioContext.state === 'suspended') {
+            this.audioContext.resume().catch(err => {
+                console.error("Failed to resume audio context:", err);
+            });
+        }
+
+        // Check if we have valid audio data
+        if (!samples || samples.length === 0) {
+            console.warn("Received empty audio data");
             return;
         }
 

--- a/speech-to-speech/workshops/react-client/src/helper/audioPlayerProcessor.worklet.js
+++ b/speech-to-speech/workshops/react-client/src/helper/audioPlayerProcessor.worklet.js
@@ -17,6 +17,13 @@ class ExpandableBuffer {
 
         if (this.writeIndex + samples.length <= this.buffer.length) {
             // Enough space to append the new samples
+            this.buffer.set(samples, this.writeIndex);
+            this.writeIndex += samples.length;
+            if (this.writeIndex - this.readIndex >= this.initialBufferLength) {
+                // Filled the initial buffer length, so we can start playback with some cushion
+                this.isInitialBuffering = false;
+            }
+            return;
         }
         else {
             // Not enough space ...
@@ -35,6 +42,7 @@ class ExpandableBuffer {
             this.writeIndex -= this.readIndex;
             this.readIndex = 0;
         }
+        // This code is now only reached if we had to resize the buffer
         this.buffer.set(samples, this.writeIndex);
         this.writeIndex += samples.length;
         if (this.writeIndex - this.readIndex >= this.initialBufferLength) {


### PR DESCRIPTION
- Fix critical bug in ExpandableBuffer.write() where audio samples werent

*Issue #, if available:*
#134 

*Description of changes:*
Audio playback in speech-to-speech/workshops/react-client is not working.

To reproduce:
1. Run the python-server
2. Runs `pnpm install` in the speech-to-speech/workshops/react-client
3. Runs `pnpm run start` in speech-to-speech/workshops/react-client
4. The audio playback is not working when accessing http://localhost:3000/proxy/3000

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
