### PR TITLE
fix: improve session termination sequence in Nova Sonic console-pytho…

### DIFF
--- a/speech-to-speech/sample-codes/console-python/nova_sonic.py
+++ b/speech-to-speech/sample-codes/console-python/nova_sonic.py
@@ -435,7 +435,6 @@ class BedrockStreamManager:
         self.input_subject.on_completed()
         self.audio_subject.on_completed()
 
-        self.is_active = False
         if self.response_task and not self.response_task.done():
             self.response_task.cancel()
         

--- a/speech-to-speech/sample-codes/console-python/nova_sonic_simple.py
+++ b/speech-to-speech/sample-codes/console-python/nova_sonic_simple.py
@@ -347,10 +347,7 @@ async def main():
     
     # Wait for user to press Enter to stop
     await asyncio.get_event_loop().run_in_executor(None, input)
-    
-    # End session
-    nova_client.is_active = False
-    
+        
     # First cancel the tasks
     tasks = []
     if not playback_task.done():
@@ -362,11 +359,14 @@ async def main():
     if tasks:
         await asyncio.gather(*tasks, return_exceptions=True)
     
+    # End session
+    await nova_client.end_session()
+    nova_client.is_active = False
+
     # cancel the response task
     if nova_client.response and not nova_client.response.done():
         nova_client.response.cancel()
-    
-    await nova_client.end_session()
+
     print("Session ended")
 
 if __name__ == "__main__":

--- a/speech-to-speech/sample-codes/console-python/nova_sonic_tool_use.py
+++ b/speech-to-speech/sample-codes/console-python/nova_sonic_tool_use.py
@@ -744,7 +744,6 @@ class BedrockStreamManager:
         for task in self.pending_tool_tasks.values():
             task.cancel()
 
-        self.is_active = False
         if self.response_task and not self.response_task.done():
             self.response_task.cancel()
 


### PR DESCRIPTION
…n sample implementations

This commit fixes session termination issues by sending prompt_end and session_end events across all three Nova Sonic console-python implementations:

1. In nova_sonic_simple.py:
   - Reordered the session termination sequence to ensure proper cleanup of the input stream by sending prompt_end.

2. In nova_sonic.py and nova_sonic_tool_use.py:
   - Removed premature `self.is_active = False` flag in the `end_session` method

*Issue #, if available:*
There's no corresponding open issue in the repo but we can clearly see that the prompt_end/session_end are not being sent to Bedrock before tearing down.

*Description of changes:*

This commit fixes session termination issues by sending prompt_end and session_end events across all three Nova Sonic console-python implementations before the request is torn down.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
I confirm.
