### PR TITLE
Fix ClusterRestrictedInstanceGroupSpecification EnvironmentConfig format

### DIFF
--- a/customization/SageMakerHyperPod/cli_utility/00_setup/create_hp_cluster.sh
+++ b/customization/SageMakerHyperPod/cli_utility/00_setup/create_hp_cluster.sh
@@ -336,12 +336,10 @@ cat > updated_cluster_config.json << EOF
         }
       ],
       "OverrideVpcConfig": ${vpc_config},
-      "TrustedEnvironment": {
-        "Config": {
-          "FSxLustreConfig": {
+      "EnvironmentConfig": {
+        "FSxLustreConfig": {
             "SizeInGiB": ${restricted_fsx_size},
             "PerUnitStorageThroughput": ${restricted_fsx_throughput}
-          }
         }
       }
     }


### PR DESCRIPTION
*Description of changes:*

API spec for ClusterRestrictedInstanceGroupSpecification has diverged since this was released, and the variable name for environment per docs (https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ClusterRestrictedInstanceGroupSpecification.html) is `EnvironmentConfig` rather than `TrustedEnvironment`. 

This currently causes the cluster update API to fail with:
```
Parameter validation failed:
Missing required parameter in RestrictedInstanceGroups[0]: "EnvironmentConfig"
Unknown parameter in RestrictedInstanceGroups[0]: "TrustedEnvironment", must be one of: InstanceCount, InstanceGroupName, InstanceType, ExecutionRole, ThreadsPerCore, InstanceStorageConfigs, OnStartDeepHealthChecks, TrainingPlanArn, OverrideVpcConfig, ScheduledUpdateConfig, EnvironmentConfig
```

