### PR TITLE
Fix container image list formatting

### DIFF
--- a/customization/SageMakerHyperPod/cli_utility/01_Hyperpod_manager/hyperpod_job_manager.sh
+++ b/customization/SageMakerHyperPod/cli_utility/01_Hyperpod_manager/hyperpod_job_manager.sh
@@ -131,7 +131,7 @@ fi
 show_containers() {
     print_section "Available Containers"
     for i in "${!CONTAINER_NAMES[@]}"; do
-        echo "  ${CYAN}$i)${NC} ${CONTAINER_NAMES[$i]}"
+        echo -e "  ${CYAN}$i)${NC} ${CONTAINER_NAMES[$i]}"
         echo "     ${CONTAINER_URIS[$i]}"
         echo ""
     done


### PR DESCRIPTION
*Description of changes:*

Current echo missing the `-e` flag making the cli render it incorrectly:
```
▶ Available Containers

  \033[0;36m0)\033[0m nova-sft
     708977205387.dkr.ecr.us-east-1.amazonaws.com/nova-fine-tune-repo:SM-HP-SFT-latest

  \033[0;36m1)\033[0m nova-dpo
     708977205387.dkr.ecr.us-east-1.amazonaws.com/nova-fine-tune-repo:SM-HP-DPO-latest

  \033[0;36m2)\033[0m nova-ppo
     078496829476.dkr.ecr.us-west-2.amazonaws.com/nova-fine-tune-repo:HP-PPO-latest

  \033[0;36m3)\033[0m nova-cpt
     078496829476.dkr.ecr.us-west-2.amazonaws.com/nova-fine-tune-repo:HP-CPT-latest

  \033[0;36m4)\033[0m nova-eval
     708977205387.dkr.ecr.us-east-1.amazonaws.com/nova-evaluation-repo:SM-HP-Eval-latest
```
