### PR TITLE
Add validation logic for DPO

### DIFF
--- a/customization/bedrock-finetuning/understanding/dataset_validation/README.md
+++ b/customization/bedrock-finetuning/understanding/dataset_validation/README.md
@@ -8,8 +8,13 @@ Install the last version of python [here](https://www.python.org/downloads/) if 
 Download the `dataset_validation` folder, `cd` into the root directory, and run the dataset validation script:
 
 ```
-python3 nova_ft_dataset_validator.py -i <file path> -m <model name>
+python3 nova_ft_dataset_validator.py -i <file path> -m <model name> -t <task type>
 ```
+
+- Task type options:
+    - sft: Supervised Fine-Tuning
+    - dpo: Direct Preference Optimization
+
 
 - Model name options
     - micro: Nova Micro Model


### PR DESCRIPTION
*Issue #, if available:*

### Description of changes

Add validation logic for DPO

### Testing
```
% python3 nova_ft_dataset_validator.py -i train_256_samples.jsonl -m micro -t dpo
Loaded 256 samples from train_256_samples.jsonl
Validating samples for model: micro
Using task: TaskType.DPO
Validation successful, all samples passed!
```

```
% python3 nova_ft_dataset_validator.py -i train_256_samples.jsonl -m micro -t sft
Loaded 256 samples from train_256_samples.jsonl
Validating samples for model: micro
Using task: TaskType.SFT
Traceback (most recent call last):
...
NovaClientError: Validation failed for samples: [0, 1, ...255]

Note: Sample IDs are zero-indexed.

Sample 0:
  - Location ('messages', 1, 'content'): Field required (type=missing)

.
.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
