### PR TITLE
Add pins for the aws_sdk_bedrock_runtime runtime

### DIFF
--- a/speech-to-speech/repeatable-patterns/chat-history-logger/requirements.txt
+++ b/speech-to-speech/repeatable-patterns/chat-history-logger/requirements.txt
@@ -2,4 +2,4 @@ pyaudio>=0.2.13
 rx>=3.2.0
 smithy-aws-core>=0.0.1
 pytz
-aws_sdk_bedrock_runtime
+aws_sdk_bedrock_runtime<0.1.0

--- a/speech-to-speech/repeatable-patterns/langchain-knowledge-base/requirements.txt
+++ b/speech-to-speech/repeatable-patterns/langchain-knowledge-base/requirements.txt
@@ -6,4 +6,4 @@ chromadb>=0.4.18
 pypdf>=3.15.1
 typing-extensions>=4.5.0
 pydantic>=2.4.2
-aws_sdk_bedrock_runtime
+aws_sdk_bedrock_runtime<0.1.0

--- a/speech-to-speech/sample-codes/console-python/requirements.txt
+++ b/speech-to-speech/sample-codes/console-python/requirements.txt
@@ -2,4 +2,4 @@ pyaudio>=0.2.13
 rx>=3.2.0
 smithy-aws-core>=0.0.1
 pytz
-aws_sdk_bedrock_runtime
+aws_sdk_bedrock_runtime<0.1.0

--- a/speech-to-speech/workshops/livekit/requirements.txt
+++ b/speech-to-speech/workshops/livekit/requirements.txt
@@ -1,3 +1,3 @@
 livekit-agents==1.2.1
 livekit-plugins-aws==1.2.1
-aws_sdk_bedrock_runtime
+aws_sdk_bedrock_runtime<0.1.0

--- a/speech-to-speech/workshops/python-server/requirements.txt
+++ b/speech-to-speech/workshops/python-server/requirements.txt
@@ -4,6 +4,6 @@ scipy==1.15.2
 rx==3.2.0
 websockets==15.0.1
 requests==2.32.3
-aws_sdk_bedrock_runtime
+aws_sdk_bedrock_runtime<0.1.0
 mcp==1.13.1
 strands-agents==0.1.6


### PR DESCRIPTION
## Problem
This examples directory currently specifies an unbounded dependency on `aws_sdk_bedrock_runtime` in `requirements.txt` files. This SDK is in an experimental phase which means there is likely to be breaking changes in subsequent releases. Breaking changes will cause existing examples to break when users install the latest version due to the unbounded dependency.

## Solution
This PR adds an upper bound constraint (aws_sdk_bedrock_runtime<0.1.0) to ensure existing examples continue to work with the v0.0.x series. This prevents unexpected failures while giving us time to update the examples for compatibility with future versions. Once the examples are updated to handle the breaking changes, we can bump the pinned version accordingly.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
