### PR TITLE
Support aws_sdk_bedrock_runtime v0.1.x

### DIFF
--- a/speech-to-speech/repeatable-patterns/chat-history-logger/nova_sonic.py
+++ b/speech-to-speech/repeatable-patterns/chat-history-logger/nova_sonic.py
@@ -13,7 +13,7 @@ import time
 import inspect
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.models import InvokeModelWithBidirectionalStreamInputChunk, BidirectionalInputPayloadPart
-from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
+from aws_sdk_bedrock_runtime.config import Config
 from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 from chat_history import ChatHistory
 

--- a/speech-to-speech/repeatable-patterns/chat-history-logger/nova_sonic.py
+++ b/speech-to-speech/repeatable-patterns/chat-history-logger/nova_sonic.py
@@ -14,7 +14,7 @@ import inspect
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.models import InvokeModelWithBidirectionalStreamInputChunk, BidirectionalInputPayloadPart
 from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
-from smithy_aws_core.credentials_resolvers.environment import EnvironmentCredentialsResolver
+from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 from chat_history import ChatHistory
 
 # Suppress warnings
@@ -296,8 +296,6 @@ class BedrockStreamManager:
             endpoint_uri=f"https://bedrock-runtime.{self.region}.amazonaws.com",
             region=self.region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-            http_auth_scheme_resolver=HTTPAuthSchemeResolver(),
-            http_auth_schemes={"aws.auth#sigv4": SigV4AuthScheme()}
         )
         self.bedrock_client = BedrockRuntimeClient(config=config)
     

--- a/speech-to-speech/repeatable-patterns/chat-history-logger/requirements.txt
+++ b/speech-to-speech/repeatable-patterns/chat-history-logger/requirements.txt
@@ -2,4 +2,4 @@ pyaudio>=0.2.13
 rx>=3.2.0
 smithy-aws-core>=0.0.1
 pytz
-aws_sdk_bedrock_runtime<0.1.0
+aws_sdk_bedrock_runtime>=0.1.0,<0.2.0

--- a/speech-to-speech/repeatable-patterns/langchain-knowledge-base/nova_sonic_tool_use.py
+++ b/speech-to-speech/repeatable-patterns/langchain-knowledge-base/nova_sonic_tool_use.py
@@ -10,7 +10,7 @@ import inspect
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.models import InvokeModelWithBidirectionalStreamInputChunk, BidirectionalInputPayloadPart
 from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
-from smithy_aws_core.credentials_resolvers.environment import EnvironmentCredentialsResolver
+from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 from langchain_kb import pdf_knowledge_retrieval
 
 # Suppress warnings
@@ -272,8 +272,6 @@ class BedrockStreamManager:
             endpoint_uri=f"https://bedrock-runtime.{self.region}.amazonaws.com",
             region=self.region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-            http_auth_scheme_resolver=HTTPAuthSchemeResolver(),
-            http_auth_schemes={"aws.auth#sigv4": SigV4AuthScheme()}
         )
         self.bedrock_client = BedrockRuntimeClient(config=config)
     

--- a/speech-to-speech/repeatable-patterns/langchain-knowledge-base/nova_sonic_tool_use.py
+++ b/speech-to-speech/repeatable-patterns/langchain-knowledge-base/nova_sonic_tool_use.py
@@ -9,7 +9,7 @@ import time
 import inspect
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.models import InvokeModelWithBidirectionalStreamInputChunk, BidirectionalInputPayloadPart
-from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
+from aws_sdk_bedrock_runtime.config import Config
 from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 from langchain_kb import pdf_knowledge_retrieval
 

--- a/speech-to-speech/repeatable-patterns/langchain-knowledge-base/requirements.txt
+++ b/speech-to-speech/repeatable-patterns/langchain-knowledge-base/requirements.txt
@@ -6,4 +6,4 @@ chromadb>=0.4.18
 pypdf>=3.15.1
 typing-extensions>=4.5.0
 pydantic>=2.4.2
-aws_sdk_bedrock_runtime<0.1.0
+aws_sdk_bedrock_runtime>=0.1.0,<0.2.0

--- a/speech-to-speech/repeatable-patterns/token-usage-logger/nova_sonic.py
+++ b/speech-to-speech/repeatable-patterns/token-usage-logger/nova_sonic.py
@@ -14,7 +14,7 @@ import inspect
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.models import InvokeModelWithBidirectionalStreamInputChunk, BidirectionalInputPayloadPart
 from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
-from smithy_aws_core.credentials_resolvers.environment import EnvironmentCredentialsResolver
+from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 from chat_history_meter import ChatHistory
 
 # Suppress warnings
@@ -296,8 +296,6 @@ class BedrockStreamManager:
             endpoint_uri=f"https://bedrock-runtime.{self.region}.amazonaws.com",
             region=self.region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-            http_auth_scheme_resolver=HTTPAuthSchemeResolver(),
-            http_auth_schemes={"aws.auth#sigv4": SigV4AuthScheme()}
         )
         self.bedrock_client = BedrockRuntimeClient(config=config)
     

--- a/speech-to-speech/repeatable-patterns/token-usage-logger/nova_sonic.py
+++ b/speech-to-speech/repeatable-patterns/token-usage-logger/nova_sonic.py
@@ -13,7 +13,7 @@ import time
 import inspect
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.models import InvokeModelWithBidirectionalStreamInputChunk, BidirectionalInputPayloadPart
-from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
+from aws_sdk_bedrock_runtime.config import Config
 from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 from chat_history_meter import ChatHistory
 

--- a/speech-to-speech/repeatable-patterns/token-usage-logger/requirements.txt
+++ b/speech-to-speech/repeatable-patterns/token-usage-logger/requirements.txt
@@ -1,3 +1,3 @@
 pyaudio>=0.2.13
 pytz
-aws-sdk-bedrock-runtime
+aws_sdk_bedrock_runtime>=0.1.0,<0.2.0

--- a/speech-to-speech/sample-codes/console-python/nova_sonic.py
+++ b/speech-to-speech/sample-codes/console-python/nova_sonic.py
@@ -15,7 +15,7 @@ from rx.scheduler.eventloop import AsyncIOScheduler
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.models import InvokeModelWithBidirectionalStreamInputChunk, BidirectionalInputPayloadPart
 from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
-from smithy_aws_core.credentials_resolvers.environment import EnvironmentCredentialsResolver
+from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 
 # Suppress warnings
 warnings.filterwarnings("ignore")
@@ -204,8 +204,6 @@ class BedrockStreamManager:
             endpoint_uri=f"https://bedrock-runtime.{self.region}.amazonaws.com",
             region=self.region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-            http_auth_scheme_resolver=HTTPAuthSchemeResolver(),
-            http_auth_schemes={"aws.auth#sigv4": SigV4AuthScheme()}
         )
         self.bedrock_client = BedrockRuntimeClient(config=config)
     

--- a/speech-to-speech/sample-codes/console-python/nova_sonic.py
+++ b/speech-to-speech/sample-codes/console-python/nova_sonic.py
@@ -14,7 +14,7 @@ from rx import operators as ops
 from rx.scheduler.eventloop import AsyncIOScheduler
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.models import InvokeModelWithBidirectionalStreamInputChunk, BidirectionalInputPayloadPart
-from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
+from aws_sdk_bedrock_runtime.config import Config
 from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 
 # Suppress warnings

--- a/speech-to-speech/sample-codes/console-python/nova_sonic_simple.py
+++ b/speech-to-speech/sample-codes/console-python/nova_sonic_simple.py
@@ -7,7 +7,7 @@ import pyaudio
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.models import InvokeModelWithBidirectionalStreamInputChunk, BidirectionalInputPayloadPart
 from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
-from smithy_aws_core.credentials_resolvers.environment import EnvironmentCredentialsResolver
+from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 
 # Audio configuration
 INPUT_SAMPLE_RATE = 16000
@@ -37,8 +37,6 @@ class SimpleNovaSonic:
             endpoint_uri=f"https://bedrock-runtime.{self.region}.amazonaws.com",
             region=self.region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-            http_auth_scheme_resolver=HTTPAuthSchemeResolver(),
-            http_auth_schemes={"aws.auth#sigv4": SigV4AuthScheme()}
         )
         self.client = BedrockRuntimeClient(config=config)
     

--- a/speech-to-speech/sample-codes/console-python/nova_sonic_simple.py
+++ b/speech-to-speech/sample-codes/console-python/nova_sonic_simple.py
@@ -6,7 +6,7 @@ import uuid
 import pyaudio
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.models import InvokeModelWithBidirectionalStreamInputChunk, BidirectionalInputPayloadPart
-from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
+from aws_sdk_bedrock_runtime.config import Config
 from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 
 # Audio configuration

--- a/speech-to-speech/sample-codes/console-python/nova_sonic_tool_use.py
+++ b/speech-to-speech/sample-codes/console-python/nova_sonic_tool_use.py
@@ -13,7 +13,7 @@ import time
 import inspect
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.models import InvokeModelWithBidirectionalStreamInputChunk, BidirectionalInputPayloadPart
-from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
+from aws_sdk_bedrock_runtime.config import Config
 from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 
 # Suppress warnings

--- a/speech-to-speech/sample-codes/console-python/nova_sonic_tool_use.py
+++ b/speech-to-speech/sample-codes/console-python/nova_sonic_tool_use.py
@@ -14,7 +14,7 @@ import inspect
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.models import InvokeModelWithBidirectionalStreamInputChunk, BidirectionalInputPayloadPart
 from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
-from smithy_aws_core.credentials_resolvers.environment import EnvironmentCredentialsResolver
+from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 
 # Suppress warnings
 warnings.filterwarnings("ignore")
@@ -432,8 +432,6 @@ class BedrockStreamManager:
             endpoint_uri=f"https://bedrock-runtime.{self.region}.amazonaws.com",
             region=self.region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-            http_auth_scheme_resolver=HTTPAuthSchemeResolver(),
-            http_auth_schemes={"aws.auth#sigv4": SigV4AuthScheme()}
         )
         self.bedrock_client = BedrockRuntimeClient(config=config)
     

--- a/speech-to-speech/sample-codes/console-python/requirements.txt
+++ b/speech-to-speech/sample-codes/console-python/requirements.txt
@@ -2,4 +2,4 @@ pyaudio>=0.2.13
 rx>=3.2.0
 smithy-aws-core>=0.0.1
 pytz
-aws_sdk_bedrock_runtime<0.1.0
+aws_sdk_bedrock_runtime>=0.1.0,<0.2.0

--- a/speech-to-speech/workshops/livekit/requirements.txt
+++ b/speech-to-speech/workshops/livekit/requirements.txt
@@ -1,3 +1,3 @@
 livekit-agents==1.2.1
 livekit-plugins-aws==1.2.1
-aws_sdk_bedrock_runtime<0.1.0
+aws_sdk_bedrock_runtime>=0.1.0,<0.2.0

--- a/speech-to-speech/workshops/python-server/requirements.txt
+++ b/speech-to-speech/workshops/python-server/requirements.txt
@@ -4,6 +4,6 @@ scipy==1.15.2
 rx==3.2.0
 websockets==15.0.1
 requests==2.32.3
-aws_sdk_bedrock_runtime<0.1.0
+aws_sdk_bedrock_runtime>=0.1.0,<0.2.0
 mcp==1.13.1
 strands-agents==0.1.6

--- a/speech-to-speech/workshops/python-server/s2s_session_manager.py
+++ b/speech-to-speech/workshops/python-server/s2s_session_manager.py
@@ -8,7 +8,7 @@ import time
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.models import InvokeModelWithBidirectionalStreamInputChunk, BidirectionalInputPayloadPart
 from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
-from smithy_aws_core.credentials_resolvers.environment import EnvironmentCredentialsResolver
+from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 from integration import inline_agent, bedrock_knowledge_bases as kb, agent_core
 
 # Suppress warnings
@@ -55,8 +55,6 @@ class S2sSessionManager:
             endpoint_uri=f"https://bedrock-runtime.{self.region}.amazonaws.com",
             region=self.region,
             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-            http_auth_scheme_resolver=HTTPAuthSchemeResolver(),
-            http_auth_schemes={"aws.auth#sigv4": SigV4AuthScheme()}
         )
         self.bedrock_client = BedrockRuntimeClient(config=config)
 

--- a/speech-to-speech/workshops/python-server/s2s_session_manager.py
+++ b/speech-to-speech/workshops/python-server/s2s_session_manager.py
@@ -7,7 +7,7 @@ from s2s_events import S2sEvent
 import time
 from aws_sdk_bedrock_runtime.client import BedrockRuntimeClient, InvokeModelWithBidirectionalStreamOperationInput
 from aws_sdk_bedrock_runtime.models import InvokeModelWithBidirectionalStreamInputChunk, BidirectionalInputPayloadPart
-from aws_sdk_bedrock_runtime.config import Config, HTTPAuthSchemeResolver, SigV4AuthScheme
+from aws_sdk_bedrock_runtime.config import Config
 from smithy_aws_core.identity.environment import EnvironmentCredentialsResolver
 from integration import inline_agent, bedrock_knowledge_bases as kb, agent_core
 


### PR DESCRIPTION
> [!IMPORTANT]
> This should not be merged until `aws_sdk_bedrock_runtime` v0.1.0 is available on PyPI.

This PR adds support for `aws_sdk_bedrock_runtime` v0.1.x by addressing breaking changes released in this minor version.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
